### PR TITLE
Update code_of_conduct.md

### DIFF
--- a/.github/code_of_conduct.md
+++ b/.github/code_of_conduct.md
@@ -1,7 +1,7 @@
 # Code of Conduct
 
 This project has adopted the code of conduct defined by the 
-Contributor Covenant](https://www.contributor-covenant.org/) to 
+[Contributor Covenant](https://www.contributor-covenant.org/) to 
 clarify expected behavior in our community.
 
 For more information, see the [.NET Foundation Code of Conduct](https://dotnetfoundation.org/code-of-conduct).


### PR DESCRIPTION
Fix broken markdown link in Code of Conduct by adding missing square bracket